### PR TITLE
Impuestos trasladados

### DIFF
--- a/src/Sistrategia.SAT.CFDiWebSite/Controllers/ComprobanteController.cs
+++ b/src/Sistrategia.SAT.CFDiWebSite/Controllers/ComprobanteController.cs
@@ -467,7 +467,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Controllers
                     comprobante.Impuestos.Traslados = new List<Traslado>();
 
                     foreach (var modelTraslado in model.Traslados) {
-                        if (modelTraslado.Tasa > 0 && modelTraslado.Importe > 0) {
+                        if (modelTraslado.Tasa >= 0 && modelTraslado.Importe >= 0) {
                             comprobante.Impuestos.Traslados.Add(new Traslado {
                                 Importe = modelTraslado.Importe,
                                 Impuesto = modelTraslado.Impuesto,

--- a/src/Sistrategia.SAT.CFDiWebSite/Controllers/ComprobanteController.cs
+++ b/src/Sistrategia.SAT.CFDiWebSite/Controllers/ComprobanteController.cs
@@ -467,12 +467,15 @@ namespace Sistrategia.SAT.CFDiWebSite.Controllers
                     comprobante.Impuestos.Traslados = new List<Traslado>();
 
                     foreach (var modelTraslado in model.Traslados) {
-                        if (modelTraslado.Tasa >= 0 && modelTraslado.Importe >= 0) {
+                        if ((modelTraslado.Tasa == 0 && modelTraslado.Importe == 0) || (modelTraslado.Tasa > 0 && modelTraslado.Importe >= 0)) {
                             comprobante.Impuestos.Traslados.Add(new Traslado {
                                 Importe = modelTraslado.Importe,
                                 Impuesto = modelTraslado.Impuesto,
                                 Tasa = modelTraslado.Tasa,
                             });
+                        }
+                        else {
+                            throw new ApplicationException(String.Format("Los valores del impuesto {0} trasladado tasa {1} e importe {2} son inválidos", modelTraslado.Impuesto, modelTraslado.Tasa, modelTraslado.Importe));
                         }
                     }
 
@@ -489,7 +492,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Controllers
                     if (model.TotalImpuestosRetenidos > 0)
                         comprobante.Impuestos.TotalImpuestosRetenidos = model.TotalImpuestosRetenidos;
 
-                    if (model.TotalImpuestosTrasladados > 0)
+                    if (model.TotalImpuestosTrasladados >= 0)
                         comprobante.Impuestos.TotalImpuestosTrasladados = model.TotalImpuestosTrasladados;
 
                     comprobante.PublicKey = Guid.NewGuid();

--- a/src/Sistrategia.SAT.CFDiWebSite/Models/ComprobanteViewModels.cs
+++ b/src/Sistrategia.SAT.CFDiWebSite/Models/ComprobanteViewModels.cs
@@ -127,20 +127,16 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
                 }
             }
 
-            if (comprobante.Impuestos.Traslados != null && comprobante.Impuestos.Traslados.Count > 0)
-            {
+            if (comprobante.Impuestos.Traslados != null && comprobante.Impuestos.Traslados.Count > 0) {
                 this.Traslados = new List<TrasladoViewModel>();
-                foreach (Traslado traslado in comprobante.Impuestos.Traslados)
-                {
+                foreach (Traslado traslado in comprobante.Impuestos.Traslados) {
                     this.Traslados.Add(new TrasladoViewModel(traslado));
                 }
             }
 
-            if (comprobante.Impuestos.Retenciones != null && comprobante.Impuestos.Retenciones.Count > 0)
-            {
+            if (comprobante.Impuestos.Retenciones != null && comprobante.Impuestos.Retenciones.Count > 0) {
                 this.Retenciones = new List<RetencionViewModel>();
-                foreach (Retencion retencion in comprobante.Impuestos.Retenciones)
-                {
+                foreach (Retencion retencion in comprobante.Impuestos.Retenciones) {
                     this.Retenciones.Add(new RetencionViewModel(retencion));
                 }
             }
@@ -391,7 +387,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
 
         }
 
-        public ComprobanteEmisorDetailViewModel(ComprobanteEmisor emisor) {        
+        public ComprobanteEmisorDetailViewModel(ComprobanteEmisor emisor) {
             if (emisor == null)
                 throw new ArgumentNullException("emisor");
 
@@ -532,7 +528,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
             this.Domicilio = new UbicacionViewModel();
         }
 
-        public ComprobanteReceptorDetailsViewModel(ComprobanteReceptor receptor) {        
+        public ComprobanteReceptorDetailsViewModel(ComprobanteReceptor receptor) {
             if (receptor == null)
                 throw new ArgumentNullException("receptor");
 
@@ -569,6 +565,9 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
     public class ComprobanteHtmlViewModel
     {
         public ComprobanteHtmlViewModel(Comprobante comprobante) {
+
+            this.Traslados = new List<ComprobanteImpuestoTrasladoTotalPorTipoViewModel>();
+
             if (comprobante == null)
                 throw new ArgumentNullException("comprobante");
 
@@ -587,13 +586,26 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
                 }
             }
 
+            if (comprobante.Impuestos.Traslados != null && comprobante.Impuestos.Traslados.Count > 0) {
+                this.Traslados = comprobante.Impuestos.Traslados
+                    .GroupBy(traslado => new { traslado.Impuesto, traslado.Tasa })
+                    .OrderByDescending(traslado => traslado.First().Impuesto)
+                    .ThenBy(traslado => traslado.First().Tasa)
+                    .Select(trasladoGrouped =>
+                        new ComprobanteImpuestoTrasladoTotalPorTipoViewModel() {
+                            Tasa = String.Format("{0}% {1}", (int)trasladoGrouped.First().Tasa, trasladoGrouped.First().Impuesto),
+                            Importe = String.Format("{0:C2}", trasladoGrouped.Sum(t => t.Importe))
+                        }
+                    ).ToList();
+            }
+
             this.PublicKey = comprobante.PublicKey;
             this.TipoDeComprobante = comprobante.TipoDeComprobante;
             this.Fecha = comprobante.Fecha.ToString("dd/MM/yyyy HH:mm:ss");
             this.Serie = comprobante.Serie;
             this.Folio = comprobante.Folio;
 
-            
+
 
             //this.FolioFiscal = comprobante.
 
@@ -688,7 +700,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
         public string MetodoDePago { get; set; }
         public string MetodoDePagoCode { get; set; }
         public string MetodoDePagoDescription { get; set; }
-        public string MetodoDePagoDisplayName { 
+        public string MetodoDePagoDisplayName {
             get {
                 if (this.MetodoDePagoCode != null && this.MetodoDePagoDescription != null)
                     return this.MetodoDePagoCode + "-" + this.MetodoDePagoDescription;
@@ -698,7 +710,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
                     return this.MetodoDePagoDescription;
                 else
                     return this.MetodoDePago;
-            } 
+            }
         }
         public string NumCuenta { get; set; }
         //public string NoOrden { get; set; }
@@ -722,6 +734,7 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
         public ComprobanteReceptorDetailsViewModel Receptor { get; set; }
 
         public List<ConceptoViewModel> Conceptos { get; set; }
+        public List<ComprobanteImpuestoTrasladoTotalPorTipoViewModel> Traslados { get; set; }
     }
     #endregion
 
@@ -751,7 +764,15 @@ namespace Sistrategia.SAT.CFDiWebSite.Models
     {
         [Required, DataType(DataType.Upload), Display(Name = "Archivo")]
         public HttpPostedFileBase CancelacionArchivo { get; set; }
-        
+
+    }
+    #endregion
+
+    #region ComprobanteTrasladosPorTasaViewModel
+    public class ComprobanteImpuestoTrasladoTotalPorTipoViewModel
+    {
+        public string Importe { get; set; }
+        public string Tasa { get; set; }
     }
     #endregion
 

--- a/src/Sistrategia.SAT.CFDiWebSite/Scripts/ViewModelsKO/ComprobanteCreate.js
+++ b/src/Sistrategia.SAT.CFDiWebSite/Scripts/ViewModelsKO/ComprobanteCreate.js
@@ -152,8 +152,8 @@ var ImpuestosModel = function (modelId) {
             trasladado.TrasladadoImporte = ko.observable(self.TrasladosImporte());
             trasladado.TrasladadoOrdinal = ko.observable(self.TrasladosOrdinal());
             self.TrasladosItems.push(trasladado);
-
-            self.TrasladosImporte("");
+            
+            (self.TrasladosTasa() == 0) ? self.TrasladosImporte("0.00") : self.TrasladosImporte("");
         }
     };
 
@@ -198,6 +198,13 @@ var ImpuestosModel = function (modelId) {
 
     self.RetencionesItems.subscribe(function (newValue) {
         self.RetencionesHasItems(newValue && newValue.length ? true : false);
+    });
+
+    self.TrasladosTasa.subscribe(function () {
+        if (self.TrasladosTasa() == 0)
+            self.TrasladosImporte("0.00");
+        else
+            self.TrasladosImporte("");
     });
 }
 

--- a/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/Create.cshtml
+++ b/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/Create.cshtml
@@ -210,10 +210,10 @@
                 <input type="text" class="form-control" data-bind="textInput: TrasladosTasa" placeholder="Tasa">
             </div>
             <div class="col-md-3">
-                <input type="number" class="form-control" data-bind="textInput: TrasladosImporte" placeholder="Importe">
+                <input type="number" class="form-control" data-bind="textInput: TrasladosImporte, enable: (TrasladosTasa() > 0)" placeholder="Importe">
             </div>
             <div class="col-md-2">
-                <button type="button" class="btn btn-default form-control" data-bind="enable: (TrasladosImpuesto().length > 0 && TrasladosImporte().length > 0 && TrasladosTasa().length > 0), click: addTraslado">Agregar</button>
+                <button type="button" class="btn btn-default form-control" data-bind="enable: ((TrasladosImpuesto().length > 0 && TrasladosImporte().length > 0 && TrasladosTasa().length > 0) || (TrasladosImpuesto() && TrasladosTasa() == 0)), click: addTraslado">Agregar</button>
             </div>
             <div class="col-md-12"><br /></div>
             <div class="col-md-12" data-bind="visible: TrasladosHasItems()">
@@ -515,9 +515,6 @@
         conceptos_model.Cantidad(1);
         impuestos_model.TrasladosImpuesto("IVA");
         impuestos_model.TrasladosTasa("16.00");
-
-
-
 
         initial_model.MetodoDePagoId.subscribe(function (newValue) {
             if (newValue == '11' || newValue == '12' || newValue == '13' || newValue == '17' || newValue == '') //[tipo_metodo_de_pago_id]

--- a/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ShowHtml.cshtml
+++ b/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ShowHtml.cshtml
@@ -319,11 +319,13 @@
                                         <td width="73%" class="center_item">$@Model.SubTotal.ToString("#,##0.00")</td>
                                       </tr>
 
-                                      <tr>
-                                        <td class="center_item">16% IVA</td>
-                                        <td class="center_item">$@Model.IVA.ToString("#,##0.00")</td>
-                                      </tr>
 
+                                        @foreach (var traslado in Model.Traslados) {
+                                            <tr>
+                                                <td class="center_item">@traslado.Tasa</td>
+                                                <td class="center_item">@traslado.Importe</td>
+                                            </tr>
+                                        }
 
                                       <tr>
                                         <td class="center_item">Total</td>

--- a/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ddm1.cshtml
+++ b/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ddm1.cshtml
@@ -321,10 +321,12 @@
                                         <td width="73%" class="center_item">$@Model.SubTotal.ToString("#,##0.00")</td>
                                       </tr>
 
-                                      <tr>
-                                        <td class="center_item">16% IVA</td>
-                                        <td class="center_item">$@Model.IVA.ToString("#,##0.00")</td>
-                                      </tr>
+                                     @foreach (var traslado in Model.Traslados) {
+                                        <tr>
+                                            <td class="center_item">@traslado.Tasa</td>
+                                            <td class="center_item">@traslado.Importe</td>
+                                        </tr>
+                                     }
 
 
                                       <tr>

--- a/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ddm2.cshtml
+++ b/src/Sistrategia.SAT.CFDiWebSite/Views/Comprobante/ddm2.cshtml
@@ -319,10 +319,12 @@
                                         <td width="73%" class="center_item">$@Model.SubTotal.ToString("#,##0.00")</td>
                                       </tr>
 
-                                      <tr>
-                                        <td class="center_item">16% IVA</td>
-                                        <td class="center_item">$@Model.IVA.ToString("#,##0.00")</td>
-                                      </tr>
+                                        @foreach (var traslado in Model.Traslados) {
+                                            <tr>
+                                                <td class="center_item">@traslado.Tasa</td>
+                                                <td class="center_item">@traslado.Importe</td>
+                                            </tr>
+                                        }
 
 
                                       <tr>


### PR DESCRIPTION
On create Comprobante, it is allowed to enter taxes with rate or amount equals to 0. In view Comprobante/ShowHtml, taxes are displayed grouped by type and rate. This fix #33 